### PR TITLE
Use exit codes correctly

### DIFF
--- a/version.go
+++ b/version.go
@@ -22,7 +22,7 @@ func processError(err error) {
 	if err != nil {
 		if booleanMode {
 			fmt.Print("false")
-			os.Exit(0)
+			os.Exit(1)
 		} else {
 			log.Fatal(err)
 		}
@@ -130,6 +130,7 @@ func main() {
 				log.Printf("%s satisfies constraints %s", ver, constraints)
 			} else {
 				fmt.Print("true")
+				os.Exit(0)
 			}
 		} else {
 			processError(fmt.Errorf("%s doesn't satisfies constraints %s", ver, constraints))


### PR DESCRIPTION
This PR modifies the version script to use the exit code `0` when the version satisfies constraints in boolean mode, and `1` when it doesn't. This means that bash which uses this command can look like this:

```
if ./version -b '>1.0.27' '1.0.27'; then echo "lorem"; fi
if ! ./version -b '>1.0.27' '1.0.27'; then echo "lorem"; fi
> lorem
```

instead of this:

```
VERSION_COMPARISON="$(./version -b '>1.0.27' '1.0.27')"
if [ "$VERSION_COMPARISON" = "true" ]; then echo "lorem"; fi
if [ "$VERSION_COMPARISON" = "false" ]; then echo "lorem"; fi
> lorem
```

You can read about exit codes here: https://tldp.org/LDP/abs/html/exitcodes.html

Fixes #1 